### PR TITLE
Maintain information about wrapped functions for easier introspection

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,9 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Changed the @indexer decorator to maintain the information about the wrapped
+  function (__doc__, __module__, __name__, etc).
+  [dokai]
 
 
 1.0.1 (2012-12-14)
@@ -46,7 +48,7 @@ Changelog
 
 - Updated the interface to match the developments of similar functionality
   on CMF trunk. This means that indexers are now multi-adapters on
-  (object, catalog), and the keyword arguments (including the implicit 
+  (object, catalog), and the keyword arguments (including the implicit
   'portal' parameter) are gone.
   [optilude]
 

--- a/plone/indexer/delegate.py
+++ b/plone/indexer/delegate.py
@@ -1,6 +1,7 @@
 from zope.interface import implements
 from zope.interface.declarations import Implements, implementedBy
 from plone.indexer.interfaces import IIndexer
+from functools import update_wrapper
 
 
 class DelegatingIndexer(object):
@@ -25,6 +26,7 @@ class DelegatingIndexerFactory(object):
     def __init__(self, callable):
         self.callable = callable
         self.__implemented__ = Implements(implementedBy(DelegatingIndexer))
+        update_wrapper(self, callable)
 
     def __call__(self, object, catalog=None):
         return DelegatingIndexer(object, catalog, self.callable)

--- a/plone/indexer/tests.py
+++ b/plone/indexer/tests.py
@@ -4,11 +4,27 @@ from zope.testing import doctestunit
 from zope.component import testing
 
 
+class TestWrapperUpdate(unittest.TestCase):
+
+    def test_wrapper_update(self):
+        from plone.indexer import indexer
+        from zope.interface import Interface
+
+        @indexer(Interface)
+        def my_func(obj):
+            """My custom docstring."""
+
+        self.assertEqual(my_func.__doc__, 'My custom docstring.')
+        self.assertEqual(my_func.__module__, 'plone.indexer.tests')
+        self.assertEqual(my_func.__name__, 'my_func')
+
+
 def test_suite():
     return unittest.TestSuite([
         doctestunit.DocFileSuite(
             'README.txt', package='plone.indexer',
             setUp=testing.setUp, tearDown=testing.tearDown),
+        unittest.makeSuite(TestWrapperUpdate),
         ])
 
 if __name__ == '__main__':


### PR DESCRIPTION
Now the @indexer decorated function has the `__doc__`,`__module__`,`__name__`, etc information from the original wrapped function.

This is particularly useful when generating documentation for code
using something like Sphinx's autodoc extension. Previously all the
@indexer decorated functions had the (same) documentation of the DelegatingIndexerFactory class instead of the wrapped functions making the autogenerated documentation rather pointless.
