### PR TITLE
fix plone/Products.CMFPlone #2469

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,13 @@ New:
 
 Fixes:
 
-- *add item here*
+- fix https://github.com/plone/Products.CMFPlone/issues/2469:
+  "Subobjects are indexing attributes of parent".
+  Allow only direct attributes and acquired PythonScripts,
+  but not aqcquired attributes.
+  Indexers and PythonScripts are able to handle this explicitly,
+  because they get the acquisition-wrapped object.
+  [jensens]
 
 
 1.0.4 (2016-02-25)

--- a/plone/indexer/decorator.py
+++ b/plone/indexer/decorator.py
@@ -41,7 +41,7 @@ class indexer(adapter):
         elif len(interfaces) > 2:
             raise ValueError(
                 u'The @indexer decorator takes at most two interfaces as '
-                u'arguments.'
+                u'arguments.',
             )
         adapter.__init__(self, *interfaces)
 

--- a/plone/indexer/tests.py
+++ b/plone/indexer/tests.py
@@ -28,5 +28,6 @@ def test_suite():
         unittest.makeSuite(TestWrapperUpdate),
     ])
 
+
 if __name__ == '__main__':
     unittest.main(defaultTest='test_suite')


### PR DESCRIPTION
Subobjects no longer are indexing attributes of parent. This probably speeds up Plone too.

see plone/Products.CMFPlone#2469

merge this first, then https://github.com/plone/Products.CMFPlone/pull/2470