### PR TITLE
Fixed: doctests on Python 2 were not correctly checked.

### DIFF
--- a/news/7.bugfix
+++ b/news/7.bugfix
@@ -1,0 +1,1 @@
+Fixed: doctests on Python 2 were not correctly checked.  [maurits]

--- a/plone/indexer/README.rst
+++ b/plone/indexer/README.rst
@@ -163,7 +163,7 @@ We have a compatibility alias in this package for use with CMF 2.1.
     ...                 indexed_value = getattr(object, idx)
     ...                 if callable(indexed_value):
     ...                     indexed_value = indexed_value()
-    ...                 print(idx, "=", indexed_value)
+    ...                 print("{0} = {1}".format(idx, indexed_value))
     ...             except (AttributeError, TypeError,):
     ...                 pass
 

--- a/plone/indexer/tests.py
+++ b/plone/indexer/tests.py
@@ -25,7 +25,7 @@ class TestWrapperUpdate(unittest.TestCase):
 class Py23DocChecker(doctest.OutputChecker):
     def check_output(self, want, got, optionflags):
         if six.PY2:
-            got = re.sub("u'(.*?)'", "'\\1'", want)
+            got = re.sub("u'(.*?)'", "'\\1'", got)
         return doctest.OutputChecker.check_output(self, want, got, optionflags)
 
 


### PR DESCRIPTION
Fixes https://github.com/plone/plone.indexer/issues/7